### PR TITLE
[WIP] make it possible to enable watchOptions poll for webpack

### DIFF
--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.js
@@ -3,7 +3,8 @@ const config = {
         dev: {
             devMiddleware: {
                 noInfo: true,
-                quiet: false
+                quiet: false,
+                poll: false
             },
             hotMiddleware: {
                 overlay: true,

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.js
@@ -4,7 +4,8 @@ const config = {
             devMiddleware: {
                 noInfo: true,
                 quiet: false,
-                poll: false
+                poll: false,
+                aggregateTimeout: undefined
             },
             hotMiddleware: {
                 overlay: true,

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -2,7 +2,8 @@ import {
     isString,
     isBoolean,
     isPath,
-    isArray
+    isArray,
+    oneOf
 } from 'roc/validators';
 
 const meta = {
@@ -37,7 +38,7 @@ const meta = {
                 devMiddleware: {
                     noInfo: isBoolean,
                     quiet: isBoolean,
-                    poll: isBoolean
+                    poll: oneOf(isBoolean, isString)
                 },
                 hotMiddleware: {
                     reload: isBoolean,

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -55,7 +55,7 @@ const meta = {
         converters: {
             dev: {
                 devMiddleware: {
-                    poll: toBooleanOrInteger,
+                    poll: toBooleanOrInteger
                 }
             }
         }

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -1,4 +1,4 @@
-import automaticConverter from 'roc/converters/automatic';
+import { toBooleanOrInteger } from 'roc/converters';
 import {
     isString,
     isBoolean,
@@ -55,7 +55,7 @@ const meta = {
         converters: {
             dev: {
                 devMiddleware: {
-                    poll: automaticConverter,
+                    poll: toBooleanOrInteger,
                 }
             }
         }

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -39,7 +39,7 @@ const meta = {
                 devMiddleware: {
                     noInfo: isBoolean,
                     quiet: isBoolean,
-                    poll: oneOf(isBoolean, isString),
+                    poll: oneOf(isBoolean, isInteger),
                     aggregateTimeout: isInteger
                 },
                 hotMiddleware: {

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -16,8 +16,7 @@ const meta = {
                 devMiddleware: {
                     noInfo: 'If no info should be sent to the console.',
                     quiet: 'If nothing should be sent to the console.',
-                    poll: 'If polling should be enabled. It is the solution ' +
-                        'whenever you want a VM to notice changes made outside that VM.'
+                    poll: 'If polling should be enabled. [https://github.com/webpack/watchpack#api]'
                 },
                 hotMiddleware: {
                     reload: 'If the browser should be reloaded if it fails to hot update the code.',

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -1,3 +1,4 @@
+import automaticConverter from 'roc/converters/automatic';
 import {
     isString,
     isBoolean,
@@ -47,6 +48,14 @@ const meta = {
                     overlay: isBoolean,
                     noInfo: isBoolean,
                     quiet: isBoolean
+                }
+            }
+        },
+
+        converters: {
+            dev: {
+                devMiddleware: {
+                    poll: automaticConverter,
                 }
             }
         }

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -14,7 +14,9 @@ const meta = {
             dev: {
                 devMiddleware: {
                     noInfo: 'If no info should be sent to the console.',
-                    quiet: 'If nothing should be sent to the console.'
+                    quiet: 'If nothing should be sent to the console.',
+                    poll: 'If polling should be enabled. It is the solution ' +
+                        'whenever you want a VM to notice changes made outside that VM.'
                 },
                 hotMiddleware: {
                     reload: 'If the browser should be reloaded if it fails to hot update the code.',
@@ -34,7 +36,8 @@ const meta = {
                 debug: isString,
                 devMiddleware: {
                     noInfo: isBoolean,
-                    quiet: isBoolean
+                    quiet: isBoolean,
+                    poll: isBoolean
                 },
                 hotMiddleware: {
                     reload: isBoolean,

--- a/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
+++ b/packages/roc-package-webpack-web-dev/src/config/roc.config.meta.js
@@ -3,6 +3,7 @@ import {
     isBoolean,
     isPath,
     isArray,
+    isInteger,
     oneOf
 } from 'roc/validators';
 
@@ -16,7 +17,8 @@ const meta = {
                 devMiddleware: {
                     noInfo: 'If no info should be sent to the console.',
                     quiet: 'If nothing should be sent to the console.',
-                    poll: 'If polling should be enabled. [https://github.com/webpack/watchpack#api]'
+                    poll: 'If polling should be enabled. [https://github.com/webpack/watchpack#api]',
+                    aggregateTimeout: 'Fire aggregated events. [https://github.com/webpack/watchpack#api]'
                 },
                 hotMiddleware: {
                     reload: 'If the browser should be reloaded if it fails to hot update the code.',
@@ -37,7 +39,8 @@ const meta = {
                 devMiddleware: {
                     noInfo: isBoolean,
                     quiet: isBoolean,
-                    poll: oneOf(isBoolean, isString)
+                    poll: oneOf(isBoolean, isString),
+                    aggregateTimeout: isInteger
                 },
                 hotMiddleware: {
                     reload: isBoolean,

--- a/packages/roc-package-webpack-web-dev/src/watcher/client.js
+++ b/packages/roc-package-webpack-web-dev/src/watcher/client.js
@@ -19,6 +19,7 @@ export default function client(compiler) {
         if (!compiler) {
             return reject(new Error('A compiler instance must be passed in order to watch client!'));
         }
+
         const devPort = getDevPort();
 
         const server = koa();
@@ -28,7 +29,10 @@ export default function client(compiler) {
                 // Let the publicPath be / since we want it to be based on the root of the dev server
                 publicPath: '/',
                 noInfo: devSettings.devMiddleware.noInfo,
-                quiet: devSettings.devMiddleware.quiet
+                quiet: devSettings.devMiddleware.quiet,
+                watchOptions: {
+                    poll: devSettings.devMiddleware.poll
+                }
             })
         );
 

--- a/packages/roc-package-webpack-web-dev/src/watcher/client.js
+++ b/packages/roc-package-webpack-web-dev/src/watcher/client.js
@@ -31,6 +31,7 @@ export default function client(compiler) {
                 noInfo: devSettings.devMiddleware.noInfo,
                 quiet: devSettings.devMiddleware.quiet,
                 watchOptions: {
+                    aggregateTimeout: devSettings.devMiddleware.aggregateTimeout,
                     poll: devSettings.devMiddleware.poll
                 }
             })


### PR DESCRIPTION
Polling is the solution whenever you want a VM to notice changes made outside that VM. 
