### PR TITLE
Made resources from settings be added before entry

### DIFF
--- a/packages/roc-package-webpack-web-dev/src/builder/index.js
+++ b/packages/roc-package-webpack-web-dev/src/builder/index.js
@@ -35,7 +35,7 @@ export default ({ previousValue: rocBuilder }) => (target) => {
             const makeAllPathsAbsolute = (input) => input.map((elem) => getAbsolutePath(elem));
 
             const resources = makeAllPathsAbsolute(buildSettings.resources);
-            buildConfig.entry[info.outputName] = buildConfig.entry[info.outputName].concat(resources);
+            buildConfig.entry[info.outputName] = [].concat(resources, buildConfig.entry[info.outputName]);
 
             /**
             * Devtool


### PR DESCRIPTION
This means that for example stylesheets in resources are added first meaning that it is possible to override them in the entry stylesheets.
