### PR TITLE
Use regular js file extension to reduce confusion

### DIFF
--- a/extensions/roc-package-webpack-web-dev/src/webpack/index.js
+++ b/extensions/roc-package-webpack-web-dev/src/webpack/index.js
@@ -46,8 +46,8 @@ export default ({ previousValue: webpackConfig }) => (target) => {
             * Output
             */
             if (DIST) {
-                newWebpackConfig.output.filename = '[name].[hash].roc.js';
-                newWebpackConfig.output.chunkFilename = '[name].[hash].roc.js';
+                newWebpackConfig.output.filename = '[name].[hash].js';
+                newWebpackConfig.output.chunkFilename = '[name].[hash].js';
             }
 
             /**


### PR DESCRIPTION
Don't use '.roc.js' file extension for webpack javascript bundle names since it's regular javascript.

I have nothing against including `roc` in the filename, but currently javascript bundles have inconsistent naming compared to other assets (styles, images), and additional file extension can make somebody think that bundle file can't be included to webpage as any other script.